### PR TITLE
feat: update templates for caption module refactor

### DIFF
--- a/html/templates/main/template-caption-image.html
+++ b/html/templates/main/template-caption-image.html
@@ -7,6 +7,6 @@
     </div>
   </div>
   <div class="layout-content">
-    <div data-parent-selector="#tab_caption" data-selector="#interrogate_image" class="portal"></div>
+    <div data-parent-selector="#tab_caption" data-selector="#caption_image" class="portal"></div>
   </div>
 </div>

--- a/html/templates/main/template-caption-results.html
+++ b/html/templates/main/template-caption-results.html
@@ -18,7 +18,7 @@
             </div>
           </div>
           <div class="layout-content">
-            <div data-parent-selector="#tab_caption" data-selector="#interrogate_output_prompt" class="portal no-outline"></div>
+            <div data-parent-selector="#tab_caption" data-selector="#caption_output_prompt" class="portal no-outline"></div>
           </div>
         </div>
       </div>
@@ -33,7 +33,7 @@
                 </div>
               </div>
               <div class="layout-content">
-                <div data-parent-selector="#tab_caption" data-selector="#interrogate_clip_labels_text" class="portal no-outline"></div>
+                <div data-parent-selector="#tab_caption" data-selector="#caption_clip_labels_text" class="portal no-outline"></div>
               </div>
             </div>
           </div>
@@ -46,7 +46,7 @@
                 </div>
               </div>
               <div class="layout-content">
-                <div data-parent-selector="#tab_caption" data-selector="#interrogate_output_image" class="portal no-outline"></div>
+                <div data-parent-selector="#tab_caption" data-selector="#caption_output_image" class="portal no-outline"></div>
               </div>
             </div>
           </div>
@@ -59,22 +59,22 @@
         <div anchor="1" class="flexbox row center panel padding no-tr">
 
           <button class="sd-button only-legacy" data-click="#txt2img_nav, #txt2img_params">
-            <div data-selector="#txt2img_tab" data-parent-selector="#copy_buttons_interrogate" droppable="true" class="portal invisible">
+            <div data-selector="#txt2img_tab" data-parent-selector="#copy_buttons_caption" droppable="true" class="portal invisible">
               <div class="mask-icon icon-2txt2img"></div>
             </div>
           </button>
           <button class="sd-button only-legacy" data-click="#img2img_nav, #img2img_params">
-            <div data-selector="#img2img_tab" data-parent-selector="#copy_buttons_interrogate" droppable="true" class="portal invisible">
+            <div data-selector="#img2img_tab" data-parent-selector="#copy_buttons_caption" droppable="true" class="portal invisible">
               <div class="mask-icon icon-2img2img"></div>
             </div>
           </button>
           <button class="sd-button" data-click="#control_nav">
-            <div data-selector="#control_tab" data-parent-selector="#copy_buttons_interrogate" droppable="true" class="portal invisible">
+            <div data-selector="#control_tab" data-parent-selector="#copy_buttons_caption" droppable="true" class="portal invisible">
               <div class="mask-icon icon-2control"></div>
             </div>
           </button>
           <button class="sd-button" data-click="#caption_nav">
-            <div data-selector="#extras_tab" data-parent-selector="#copy_buttons_interrogate" droppable="true" class="portal invisible">
+            <div data-selector="#extras_tab" data-parent-selector="#copy_buttons_caption" droppable="true" class="portal invisible">
               <div class="mask-icon icon-2extras"></div>
             </div>
           </button>

--- a/html/templates/main/template-control-results.html
+++ b/html/templates/main/template-control-results.html
@@ -96,7 +96,7 @@
                       <div class="flexbox col progress-flex">
                         <div data-selector="#control_gallery_container" data-parent-selector="gradio-app" class="portal"></div>
                       </div>
-                      <div data-selector="#control_interrogate_output" data-parent-selector="#control_gallery_container" class="portal"></div>
+                      <div data-selector="#control_caption_output" data-parent-selector="#control_gallery_container" class="portal"></div>
                       <div data-selector="#control_image_fit" data-parent-selector="#control_gallery_container" class="portal"></div>
                     </div>
                     <div iconTrigger="#info_icon_btn_control" class="accordion shrink no-tr">

--- a/html/templates/main/template-img2img-results.html
+++ b/html/templates/main/template-img2img-results.html
@@ -38,7 +38,7 @@
 
         <div class="panel no-tr flexbox col">
           <div data-selector="#mode_img2img" data-parent-selector="#tab_img2img" class="portal no-bg no-padding"></div>
-          <!-- <div data-selector="#img2img_interrogate_input" data-parent-selector="#tab_img2img" class="portal"></div> -->
+          <!-- <div data-selector="#img2img_caption_input" data-parent-selector="#tab_img2img" class="portal"></div> -->
           <div class="xtabs-anchor flexbox shrink" anchorNav="#mode_img2img > .tab-nav">
             <div anchor="1" class="flexbox row center panel no-tr">
               <button class="sd-button disable">
@@ -143,7 +143,7 @@
             <div class="flexbox col progress-flex">
               <div data-selector="#img2img_gallery_container" data-parent-selector="gradio-app" class="portal"></div>
             </div>
-            <div data-selector="#img2img_interrogate_output" data-parent-selector="#img2img_gallery_container" class="portal"></div>
+            <div data-selector="#img2img_caption_output" data-parent-selector="#img2img_gallery_container" class="portal"></div>
             <div data-selector="#img2img_image_fit" data-parent-selector="#img2img_gallery_container" class="portal"></div>
           </div>
           <div iconTrigger="#info_icon_btn_img2img" class="accordion no-tr">

--- a/html/templates/main/template-txt2img-results.html
+++ b/html/templates/main/template-txt2img-results.html
@@ -39,7 +39,7 @@
           <div class="flexbox col progress-flex">
             <div data-selector="#txt2img_gallery_container" data-parent-selector="gradio-app" class="portal"></div>
           </div>
-          <div data-selector="#txt2img_interrogate_output" data-parent-selector="#txt2img_gallery_container" class="portal"></div>
+          <div data-selector="#txt2img_caption_output" data-parent-selector="#txt2img_gallery_container" class="portal"></div>
           <div data-selector="#txt2img_image_fit" data-parent-selector="#txt2img_gallery_container" class="portal"></div>
         </div>
         <div iconTrigger="#info_icon_btn_txt2img" class="accordion no-tr margin-top">

--- a/style.css
+++ b/style.css
@@ -4817,7 +4817,7 @@ div#video_params_control_tabitem .video-settings .gradio-accordion .form {
   overflow: visible;
 }
 
-.gap:has(.interrogate-clip) {
+.gap:has(.caption-clip) {
   position: relative;
 }
 
@@ -4833,9 +4833,9 @@ div#video_params_control_tabitem .video-settings .gradio-accordion .form {
   outline: none !important;
 }
 
-button.interrogate,
-button.interrogate-clip,
-button.interrogate-blip,
+button.caption,
+button.caption-clip,
+button.caption-blip,
 button.image-fit {
   opacity: 0.5;
   position: absolute;
@@ -4844,7 +4844,7 @@ button.image-fit {
   z-index: 1;
 }
 
-button.interrogate {
+button.caption {
   right: 5.8em;
 }
 
@@ -4852,16 +4852,16 @@ button.image-fit {
   right: 8.6em;
 }
 
-button.interrogate-clip {
+button.caption-clip {
   left: 1em;
 }
 
-button.interrogate-blip {
+button.caption-blip {
   left: 3em;
 }
 
-button.interrogate-clip::after,
-button.interrogate-blip::after {
+button.caption-clip::after,
+button.caption-blip::after {
   -webkit-mask-position: center center;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-size: contain;
@@ -4881,8 +4881,8 @@ button.interrogate-blip::after {
   width: 80%;
 }
 
-button.interrogate-clip:hover::after,
-button.interrogate-blip:hover::after {
+button.caption-clip:hover::after,
+button.caption-blip:hover::after {
   background-color: var(--sd-input-hover-text-color);
   mask-image: url(./html/svg/question-answer-fill.svg);
 }
@@ -5194,7 +5194,7 @@ gallery-folder:hover {
   justify-content: center;
 }
 
-#interrogate_output_prompt textarea {
+#caption_output_prompt textarea {
   flex: 1 !important;
   overflow-y: auto !important;
   min-height: 0 !important;
@@ -5250,7 +5250,7 @@ gallery-folder:hover {
 
 #vlm_system textarea,
 #vlm_prompt textarea,
-#interrogate_output_prompt textarea {
+#caption_output_prompt textarea {
   resize: vertical !important;
 }
 
@@ -5649,7 +5649,7 @@ div#changelog_result p {
 }
 
 /* Override Python height=512 and make image fill container */
-#interrogate_image {
+#caption_image {
   height: 100% !important;
   width: 100% !important;
   min-height: 256px !important;
@@ -5659,7 +5659,7 @@ div#changelog_result p {
 }
 
 /* Make image container fill available space */
-#interrogate_image .image-container {
+#caption_image .image-container {
   flex: 1 !important;
   display: flex !important;
   flex-direction: column !important;
@@ -5672,7 +5672,7 @@ div#changelog_result p {
 }
 
 /* Configure boundedheight container for interrogate image */
-#interrogate_image .image-container .center.boundedheight.flex {
+#caption_image .image-container .center.boundedheight.flex {
   width: 100% !important;
   flex: 1 !important;
   display: flex !important;
@@ -5682,14 +5682,14 @@ div#changelog_result p {
 }
 
 /* Make image fill container while maintaining aspect ratio */
-#interrogate_image img {
+#caption_image img {
   object-fit: contain !important;
   width: 100% !important;
   height: 100% !important;
 }
 
 /* Hide visual label components (not used - CLIP labels shown as text instead) */
-#interrogate_output_classes {
+#caption_output_classes {
   display: none !important;
 }
 
@@ -5706,7 +5706,7 @@ div#changelog_result p {
   min-width: 300px;
 }
 
-#interrogate_output {
+#caption_output {
   max-height: 100vh;
   overflow: hidden;
 }
@@ -5749,7 +5749,7 @@ div#changelog_result p {
   overflow: hidden;
 }
 
-#interrogate_output_prompt {
+#caption_output_prompt {
   flex: 1 !important;
   min-height: 0;
   overflow: hidden;
@@ -5758,8 +5758,8 @@ div#changelog_result p {
   height: 100% !important;
 }
 
-#interrogate_output_prompt .form,
-#interrogate_output_prompt .gradio-textbox {
+#caption_output_prompt .form,
+#caption_output_prompt .gradio-textbox {
   display: flex !important;
   flex-direction: column !important;
   flex: 1 !important;
@@ -5767,7 +5767,7 @@ div#changelog_result p {
   min-height: 0 !important;
 }
 
-#interrogate_output_prompt .gradio-textbox label {
+#caption_output_prompt .gradio-textbox label {
   display: flex !important;
   flex-direction: column !important;
   flex: 1 !important;
@@ -5812,7 +5812,7 @@ div#changelog_result p {
 }
 
 /* Make CLIP labels textbox scrollable */
-#interrogate_clip_labels_text {
+#caption_clip_labels_text {
   flex: 1 !important;
   min-height: 0 !important;
   overflow: hidden !important;
@@ -5820,8 +5820,8 @@ div#changelog_result p {
   flex-direction: column !important;
 }
 
-#interrogate_clip_labels_text .form,
-#interrogate_clip_labels_text .gradio-textbox {
+#caption_clip_labels_text .form,
+#caption_clip_labels_text .gradio-textbox {
   display: flex !important;
   flex-direction: column !important;
   flex: 1 !important;
@@ -5829,7 +5829,7 @@ div#changelog_result p {
   min-height: 0 !important;
 }
 
-#interrogate_clip_labels_text label {
+#caption_clip_labels_text label {
   display: flex !important;
   flex-direction: column !important;
   flex: 1 !important;
@@ -5837,7 +5837,7 @@ div#changelog_result p {
   height: 100% !important;
 }
 
-#interrogate_clip_labels_text textarea {
+#caption_clip_labels_text textarea {
   flex: 1 !important;
   overflow-y: auto !important;
   min-height: 0 !important;
@@ -5863,7 +5863,7 @@ div#changelog_result p {
 }
 
 /* Main Output Image container */
-#interrogate_output_image {
+#caption_output_image {
   min-height: 0;
   overflow: hidden;
   display: flex;
@@ -5873,7 +5873,7 @@ div#changelog_result p {
 }
 
 /* Configure Gradio image-container for proper sizing */
-#interrogate_output_image .image-container {
+#caption_output_image .image-container {
   flex: 1 !important;
   display: flex !important;
   flex-direction: column !important;
@@ -5886,7 +5886,7 @@ div#changelog_result p {
 }
 
 /* Configure nested Gradio containers */
-#interrogate_output_image .image-container .center.boundedheight.flex {
+#caption_output_image .image-container .center.boundedheight.flex {
   width: 100% !important;
   flex: 1 !important;
   display: flex !important;
@@ -5896,18 +5896,18 @@ div#changelog_result p {
 }
 
 /* Hide Gradio label text for Answer (use custom header instead) */
-#interrogate_output_prompt label > span {
+#caption_output_prompt label > span {
   display: none !important;
 }
 
 /* Hide Gradio label text for Output Image (use custom header instead) */
-#interrogate_output_image_display label > span,
-#interrogate_output_image_display [data-testid="block-label"] {
+#caption_output_image_display label > span,
+#caption_output_image_display [data-testid="block-label"] {
   display: none !important;
 }
 
 /* Ensure Output Image fills space and centers properly */
-#interrogate_output_image_display {
+#caption_output_image_display {
   height: 100%;
   width: 100%;
   display: flex;
@@ -5916,14 +5916,14 @@ div#changelog_result p {
   overflow: hidden;
 }
 
-#interrogate_output_image_display img {
+#caption_output_image_display img {
   object-fit: contain !important;
   width: 100% !important;
   height: 100% !important;
 }
 
 /* Position download button at top-right */
-#interrogate_output_image_display .icon-buttons {
+#caption_output_image_display .icon-buttons {
   top: 0 !important;
 }
 


### PR DESCRIPTION
Update HTML templates and styles for caption module rename:
- template-caption-image.html, template-caption-results.html
- template-control-results.html, template-img2img-results.html
- template-txt2img-results.html
- style.css adjustments