### PR TITLE
refactor: remove GFPGAN and CodeFormer sections from extras template

### DIFF
--- a/html/templates/main/template-extras-params.html
+++ b/html/templates/main/template-extras-params.html
@@ -34,11 +34,6 @@
                 <h2>PixelArt</h2>
                 <div data-parent-selector="#tab_process" data-selector="#postprocess_pixelart_accordion .gap" class="portal no-bg no-outline"></div>
 
-                <h2>GFPGAN</h2>
-                <div data-parent-selector="#tab_process" data-selector="#postprocess_gfpgan_accordion .gap" class="portal no-bg no-outline"></div>
-
-                <h2>CodeFormer</h2>
-                <div data-parent-selector="#tab_process" data-selector="#postprocess_codeformer_accordion .gap" class="portal no-bg no-outline"></div>
 
               </div>
             </div>


### PR DESCRIPTION
Remove the GFPGAN and CodeFormer portal sections from the extras params template. These face restoration backends have been removed from SD.Next.
