### PR TITLE
fix(video): align sidebar with per-engine layout refactor

### DIFF
--- a/html/templates/main/template-video-params.html
+++ b/html/templates/main/template-video-params.html
@@ -10,13 +10,9 @@
           <div class="mask-icon icon-folder-bookmark"></div>
           <span>Prompts</span>
         </button>
-        <button title="Size" tabItemId=".video_size_tabitem" tabGroup="video" id="video_params_size" class="xtabs-tab shrink">
+        <button title="Generic" tabItemId=".video_generic_tabitem" tabGroup="video" id="video_params_generic" class="xtabs-tab shrink">
           <div class="mask-icon icon-folder-grid"></div>
-          <span>Size & Inputs</span>
-        </button>
-        <button title="Models" tabItemId=".video_generic_tabitem" tabGroup="video" id="video_params_generic" class="xtabs-tab shrink">
-          <div class="mask-icon icon-folder-grid"></div>
-          <span>Models</span>
+          <span>Generic</span>
         </button>
         <button title="FramePack" tabItemId=".video_framepack_tabitem" tabGroup="video" id="video_params_framepack" class="xtabs-tab shrink">
           <div class="mask-icon icon-folder-grid"></div>
@@ -26,9 +22,9 @@
           <div class="mask-icon icon-folder-grid"></div>
           <span>LTXVideo</span>
         </button>
-        <button title="Video Output" tabItemId=".video_outputs_tabitem" tabGroup="video" id="video_params_outputs" class="xtabs-tab shrink">
+        <button title="Output" tabItemId=".video_outputs_tabitem" tabGroup="video" id="video_params_outputs" class="xtabs-tab shrink">
           <div class="mask-icon icon-folder-grid"></div>
-          <span>Video Params</span>
+          <span>Output</span>
         </button>
         <div class="only-mobile break"></div>
         <button title="Output" tabItemId=".video_output_tabitem" tabGroup="video" id="video_params_output" class="xtabs-tab only-mobile">
@@ -98,19 +94,6 @@
         </div>
 
         <div class="layout-content">
-          <div id="video_params_size_tabitem_group" class="outline-params">
-            <div id="video_params_size_tabitem" class="xtabs-item video_size_tabitem">
-              <div class="flexbox col">
-                <h2>Size</h2>
-                <div data-parent-selector="#tab_video" data-selector="#video_size" class="portal no-bg"></div>
-                <h2>Inputs</h2>
-                <div data-parent-selector="#tab_video" data-selector="#video_inputs" class="portal no-bg"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="layout-content">
           <div id="video_params_generic_tabitem_group" class="outline-params">
             <div id="video_params_generic_tabitem" class="xtabs-item video_generic_tabitem">
               <div class="flexbox col">
@@ -147,7 +130,7 @@
           <div id="video_params_outputs_tabitem_group" class="outline-params">
             <div id="video_params_outputs_tabitem" class="xtabs-item video_outputs_tabitem">
               <div class="flexbox col">
-                <h2>Video Output</h2>
+                <h2>Output</h2>
                 <div data-parent-selector="#tab_video" data-selector="#video_outputs" class="portal no-bg"></div>
               </div>
             </div>


### PR DESCRIPTION
The sdnext video tab restructure removed the shared Size/Inputs columns in favor of per-engine accordions, so the "Size & Inputs" sidebar entry portaled to elem_ids that no longer exist. Drop that entry and its tabitem group, and rename Models/Video Params to Generic/Output to match the Standard UI tab names.

Depends on the merge to core, so keeping this on draft.