### PR TITLE
feat(extras): add detailer portal to process tab

### DIFF
--- a/html/templates/main/template-extras-params.html
+++ b/html/templates/main/template-extras-params.html
@@ -25,6 +25,9 @@
                 <h2>Color Grading</h2>
                 <div data-parent-selector="#tab_process" data-selector="#process_color_grading .gap" class="portal no-bg no-outline"></div>
 
+                <h2>Detailer</h2>
+                <div data-parent-selector="#tab_process" data-selector="#extras_detailer_accordion .gap" class="portal no-bg no-outline"></div>
+
                 <h2>Remove background</h2>
                 <div data-parent-selector="#tab_process" data-selector="#postprocess_rembg_accordion .gap" class="portal no-bg no-outline"></div>
 


### PR DESCRIPTION
Add a portal targeting `#extras_detailer_accordion` so the standalone Detailer postprocess script renders in the process tab.

Partner to [SD.Next PR#4886](https://github.com/vladmandic/sdnext/pull/4886)